### PR TITLE
Improve permission check

### DIFF
--- a/install.py
+++ b/install.py
@@ -78,8 +78,8 @@ def update_font_cache(dest: Path):
 
     if shutil.which("fc-cache") is None:
         elog(
-            f"The {BLUE}'fc-cache'{NC} command was not found."
-            " Please install Fontconfig."
+            f"The {BLUE}'fc-cache'{NC} command was not found. "
+            "Please install Fontconfig."
         )
 
     try:
@@ -138,12 +138,11 @@ def main():
 
     validate_font_src_path(src)
 
-    if dest == GLOBAL_DEST:
-        if not os.access(dest, os.W_OK):
-            elog(
-                f"Permission denied to write in {BLUE}{dest}{NC}."
-                " Please execute with sudo."
-            )
+    if dest == GLOBAL_DEST and os.geteuid() != 0:
+        elog(
+            f"Insufficient permissions to write to {BLUE}{dest}{NC}. "
+            "Please run the command as root or use 'sudo'."
+        )
 
     install_fonts(src, dest)
     update_font_cache(dest)


### PR DESCRIPTION
This PR updates the permission check logic for `GLOBAL_DEST` by replacing the use of `os.access(dest, os.W_OK)` with a more robust check: `os.geteuid() != 0`.

### Changes:

- Simplifies and improves reliability of permission validation.
- Enhances the error message to clearly instruct the user to run as root or use sudo.

This change avoids edge cases where os.access() may give a false sense of writeability due to how it interacts with process privileges.

Closes #1.

